### PR TITLE
Remove portal properties usage

### DIFF
--- a/collective/plonefinder/browser/finder.py
+++ b/collective/plonefinder/browser/finder.py
@@ -593,13 +593,14 @@ class Finder(BrowserView):
         """
         # use util from plone.app.imaging to retrieve the sizes (dict of size tuples)
         image_sizes = getAllowedSizes()
-        thumb_sizes = []
-        for name in image_sizes:
-            width, height = image_sizes[name]
-            label = "%s : %ipx*%ipx" % (_(name.capitalize()), width, height)
-            url_appendix = "/@@images/image/%s" % name
-            thumb_sizes.append((name, width, height, label, url_appendix))
-        return sorted(thumb_sizes, key=lambda ts: ts[1])
+        if image_sizes:
+            thumb_sizes = []
+            for name in image_sizes:
+                width, height = image_sizes[name]
+                label = "%s : %ipx*%ipx" % (_(name.capitalize()), width, height)
+                url_appendix = "/@@images/image/%s" % name
+                thumb_sizes.append((name, width, height, label, url_appendix))
+            return sorted(thumb_sizes, key=lambda ts: ts[1])
 
         # a default
         return [

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ setup(name='collective.plonefinder',
           # -*- Extra requirements: -*-
           'collective.quickupload',
           'plone.api',
+          'plone.app.imaging',
           ],
       entry_points="""
       # -*- Entry points: -*-


### PR DESCRIPTION
This correction was already PRed against collective/collective.plonefinder's plone5 Branch. We don't really need it in our fork, but it can't hurt.